### PR TITLE
Add ESP-IDF project skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.5)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(lizardManager)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # lizardManager
+
+This repository contains an ESP-IDF project skeleton. The directory layout is:
+
+- `main/` - application source code
+- `components/` - additional components
+- `config/` - configuration files
+- `docs/` - project documentation
+
+To build the project, install ESP-IDF and run `idf.py build` in this directory.
+

--- a/components/README.md
+++ b/components/README.md
@@ -1,0 +1,1 @@
+# Components

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,3 @@
+# Configuration
+
+Place ESP-IDF configuration files here.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+This directory stores project documentation.

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "main.c" INCLUDE_DIRS ".")

--- a/main/main.c
+++ b/main/main.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+void app_main(void)
+{
+    printf("Hello Lizard Manager!\n");
+    while (true) {
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}


### PR DESCRIPTION
## Summary
- add documentation and configuration folders
- create ESP-IDF CMake files
- provide `main/` with example `app_main`
- placeholder component directory

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686d30474768832388a82a1f09a90cec