### PR TITLE
Add build and temp patterns to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Build artifacts and generated files
+build/
+
+# SDK configuration from ESP-IDF
+sdkconfig
+sdkconfig.old
+
+# Temporary files
+*.tmp
+*.temp
+*~
+*.swp
+
+# Based on GitHub's ESP-IDF.gitignore template
+# https://github.com/github/gitignore/blob/main/community/embedded/esp-idf.gitignore


### PR DESCRIPTION
## Summary
- add project `.gitignore` including build directories and temp file patterns
- reference GitHub's ESP-IDF template

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d32cee46c8323a8b711140e07937d