### PR TITLE
Add sample tests and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: espressif/idf:release-v5.0
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build firmware
+        run: idf.py build
+      - name: Build unit tests
+        run: idf.py -C tests build

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.5)
+set(EXTRA_COMPONENT_DIRS ../components)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(sensor_tests)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,14 @@
+# Unit Tests
+
+This directory contains sample unit tests for the sensor components. Tests are
+written using the Unity framework provided by ESP-IDF and build as a standalone
+application.
+
+To build the tests locally:
+
+```
+idf.py -C tests build
+```
+
+Running the resulting firmware requires an ESP32 device and the unit test
+infrastructure.

--- a/tests/main/CMakeLists.txt
+++ b/tests/main/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "test_main.c"
+                       INCLUDE_DIRS "."
+                       REQUIRES unity dht22 ds18b20 relay)

--- a/tests/main/test_main.c
+++ b/tests/main/test_main.c
@@ -1,0 +1,41 @@
+#include "unity.h"
+#include "dht22.h"
+#include "ds18b20.h"
+#include "relay.h"
+#include "driver/gpio.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_dht22_read(void)
+{
+    dht22_init(GPIO_NUM_4);
+    float t = 0, h = 0;
+    TEST_ASSERT_EQUAL(ESP_OK, dht22_read(&t, &h));
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 25.0f, t);
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 60.0f, h);
+}
+
+void test_ds18b20_read(void)
+{
+    ds18b20_init(GPIO_NUM_5);
+    float t = 0;
+    TEST_ASSERT_EQUAL(ESP_OK, ds18b20_read(&t));
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 26.5f, t);
+}
+
+void test_relay_set_state(void)
+{
+    relay_init(GPIO_NUM_2);
+    TEST_ASSERT_EQUAL(ESP_OK, relay_set_state(true));
+    TEST_ASSERT_EQUAL(ESP_OK, relay_set_state(false));
+}
+
+void app_main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_dht22_read);
+    RUN_TEST(test_ds18b20_read);
+    RUN_TEST(test_relay_set_state);
+    UNITY_END();
+}


### PR DESCRIPTION
## Summary
- add Unity-based sensor tests
- document how to build the tests
- run firmware and test builds in CI

## Testing
- `idf.py build` *(fails: command not found)*
- `idf.py -C tests build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e366986548323b5c24fa3d8d463b9