### PR TITLE
Implement sensor drivers and update tests

### DIFF
--- a/components/dht22/dht22.c
+++ b/components/dht22/dht22.c
@@ -1,13 +1,31 @@
 #include "dht22.h"
 #include "esp_log.h"
+#include "esp_rom_sys.h"
+#include "esp_timer.h"
 
 static const char *TAG = "dht22";
 static gpio_num_t dht22_pin = -1;
 
+static esp_err_t wait_level(int level, uint32_t timeout_us)
+{
+    int64_t start = esp_timer_get_time();
+    while (gpio_get_level(dht22_pin) != level) {
+        if ((esp_timer_get_time() - start) > timeout_us) {
+            return ESP_ERR_TIMEOUT;
+        }
+    }
+    return ESP_OK;
+}
+
 esp_err_t dht22_init(gpio_num_t pin)
 {
+    if (pin < 0 || pin >= GPIO_NUM_MAX) {
+        return ESP_ERR_INVALID_ARG;
+    }
     dht22_pin = pin;
-    // Normally GPIO setup would go here
+    gpio_set_direction(pin, GPIO_MODE_OUTPUT);
+    gpio_set_level(pin, 1);
+    gpio_set_pull_mode(pin, GPIO_PULLUP_ONLY);
     ESP_LOGI(TAG, "Initialized on GPIO %d", pin);
     return ESP_OK;
 }
@@ -17,9 +35,42 @@ esp_err_t dht22_read(float *temperature, float *humidity)
     if (dht22_pin < 0) {
         return ESP_ERR_INVALID_STATE;
     }
-    // Stub reading - replace with real sensor code
-    if (temperature) *temperature = 25.0f;
-    if (humidity) *humidity = 60.0f;
-    ESP_LOGI(TAG, "Read temp=%.1fC hum=%.1f%%", *temperature, *humidity);
+
+    uint8_t data[5] = {0};
+
+    // start signal
+    gpio_set_direction(dht22_pin, GPIO_MODE_OUTPUT);
+    gpio_set_level(dht22_pin, 0);
+    esp_rom_delay_us(1100);
+    gpio_set_level(dht22_pin, 1);
+    esp_rom_delay_us(40);
+    gpio_set_direction(dht22_pin, GPIO_MODE_INPUT);
+
+    if (wait_level(0, 80) != ESP_OK || wait_level(1, 80) != ESP_OK)
+        return ESP_ERR_TIMEOUT;
+
+    for (int i = 0; i < 40; i++) {
+        if (wait_level(0, 80) != ESP_OK) return ESP_ERR_TIMEOUT;
+        if (wait_level(1, 80) != ESP_OK) return ESP_ERR_TIMEOUT;
+        int64_t start = esp_timer_get_time();
+        if (wait_level(0, 80) != ESP_OK) return ESP_ERR_TIMEOUT;
+        int64_t len = esp_timer_get_time() - start;
+        data[i/8] <<= 1;
+        if (len > 40) data[i/8] |= 1;
+    }
+
+    uint8_t checksum = data[0] + data[1] + data[2] + data[3];
+    if (checksum != data[4]) {
+        return ESP_ERR_INVALID_CRC;
+    }
+
+    int16_t raw_h = (data[0] << 8) | data[1];
+    int16_t raw_t = (data[2] << 8) | data[3];
+    if (raw_t & 0x8000) raw_t = -(raw_t & 0x7FFF);
+
+    if (humidity) *humidity = raw_h / 10.0f;
+    if (temperature) *temperature = raw_t / 10.0f;
+
+    ESP_LOGI(TAG, "Read temp=%.1fC hum=%.1f%%", temperature ? *temperature : 0, humidity ? *humidity : 0);
     return ESP_OK;
 }

--- a/components/ds18b20/ds18b20.c
+++ b/components/ds18b20/ds18b20.c
@@ -1,12 +1,79 @@
 #include "ds18b20.h"
 #include "esp_log.h"
+#include "esp_rom_sys.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 static const char *TAG = "ds18b20";
 static gpio_num_t ds_pin = -1;
 
+static esp_err_t ow_reset(void)
+{
+    gpio_set_direction(ds_pin, GPIO_MODE_OUTPUT);
+    gpio_set_level(ds_pin, 0);
+    esp_rom_delay_us(480);
+    gpio_set_direction(ds_pin, GPIO_MODE_INPUT);
+    esp_rom_delay_us(70);
+    bool present = !gpio_get_level(ds_pin);
+    esp_rom_delay_us(410);
+    return present ? ESP_OK : ESP_ERR_TIMEOUT;
+}
+
+static void ow_write_bit(int bit)
+{
+    gpio_set_direction(ds_pin, GPIO_MODE_OUTPUT);
+    gpio_set_level(ds_pin, 0);
+    if (bit) {
+        esp_rom_delay_us(10);
+        gpio_set_direction(ds_pin, GPIO_MODE_INPUT);
+        esp_rom_delay_us(55);
+    } else {
+        esp_rom_delay_us(65);
+        gpio_set_direction(ds_pin, GPIO_MODE_INPUT);
+        esp_rom_delay_us(5);
+    }
+}
+
+static int ow_read_bit(void)
+{
+    gpio_set_direction(ds_pin, GPIO_MODE_OUTPUT);
+    gpio_set_level(ds_pin, 0);
+    esp_rom_delay_us(3);
+    gpio_set_direction(ds_pin, GPIO_MODE_INPUT);
+    esp_rom_delay_us(10);
+    int bit = gpio_get_level(ds_pin);
+    esp_rom_delay_us(53);
+    return bit;
+}
+
+static void ow_write_byte(uint8_t v)
+{
+    for (int i = 0; i < 8; i++) {
+        ow_write_bit((v >> i) & 1);
+    }
+}
+
+static uint8_t ow_read_byte(void)
+{
+    uint8_t val = 0;
+    for (int i = 0; i < 8; i++) {
+        val |= ow_read_bit() << i;
+    }
+    return val;
+}
+
 esp_err_t ds18b20_init(gpio_num_t pin)
 {
+    if (pin < 0 || pin >= GPIO_NUM_MAX) {
+        return ESP_ERR_INVALID_ARG;
+    }
     ds_pin = pin;
+    gpio_set_pull_mode(pin, GPIO_PULLUP_ONLY);
+    esp_err_t ret = ow_reset();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Sensor not responding");
+        return ret;
+    }
     ESP_LOGI(TAG, "Initialized on GPIO %d", pin);
     return ESP_OK;
 }
@@ -16,7 +83,23 @@ esp_err_t ds18b20_read(float *temperature)
     if (ds_pin < 0) {
         return ESP_ERR_INVALID_STATE;
     }
-    if (temperature) *temperature = 26.5f;
-    ESP_LOGI(TAG, "Read temp=%.1fC", *temperature);
+
+    if (ow_reset() != ESP_OK) return ESP_ERR_TIMEOUT;
+    ow_write_byte(0xCC); // skip ROM
+    ow_write_byte(0x44); // convert T
+    vTaskDelay(pdMS_TO_TICKS(750));
+
+    if (ow_reset() != ESP_OK) return ESP_ERR_TIMEOUT;
+    ow_write_byte(0xCC);
+    ow_write_byte(0xBE); // read scratchpad
+
+    uint8_t lsb = ow_read_byte();
+    uint8_t msb = ow_read_byte();
+    ow_reset();
+
+    int16_t raw = (msb << 8) | lsb;
+    if (temperature) *temperature = raw / 16.0f;
+
+    ESP_LOGI(TAG, "Read temp=%.1fC", temperature ? *temperature : 0);
     return ESP_OK;
 }

--- a/tests/main/test_main.c
+++ b/tests/main/test_main.c
@@ -12,8 +12,14 @@ void test_dht22_read(void)
     dht22_init(GPIO_NUM_4);
     float t = 0, h = 0;
     TEST_ASSERT_EQUAL(ESP_OK, dht22_read(&t, &h));
-    TEST_ASSERT_FLOAT_WITHIN(0.1f, 25.0f, t);
-    TEST_ASSERT_FLOAT_WITHIN(0.1f, 60.0f, h);
+    TEST_ASSERT_TRUE(t > -40 && t < 80);
+    TEST_ASSERT_TRUE(h >= 0 && h <= 100);
+}
+
+void test_dht22_invalid_state(void)
+{
+    float t, h;
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, dht22_read(&t, &h));
 }
 
 void test_ds18b20_read(void)
@@ -21,7 +27,13 @@ void test_ds18b20_read(void)
     ds18b20_init(GPIO_NUM_5);
     float t = 0;
     TEST_ASSERT_EQUAL(ESP_OK, ds18b20_read(&t));
-    TEST_ASSERT_FLOAT_WITHIN(0.1f, 26.5f, t);
+    TEST_ASSERT_TRUE(t > -55 && t < 125);
+}
+
+void test_ds18b20_invalid_state(void)
+{
+    float t;
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, ds18b20_read(&t));
 }
 
 void test_relay_set_state(void)
@@ -35,7 +47,9 @@ void app_main(void)
 {
     UNITY_BEGIN();
     RUN_TEST(test_dht22_read);
+    RUN_TEST(test_dht22_invalid_state);
     RUN_TEST(test_ds18b20_read);
+    RUN_TEST(test_ds18b20_invalid_state);
     RUN_TEST(test_relay_set_state);
     UNITY_END();
 }


### PR DESCRIPTION
## Summary
- add real DHT22 timing-based driver with error checks
- add DS18B20 1‑wire implementation
- extend tests to cover invalid states and range checking

## Testing
- `idf.py -C tests build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e3e572ee083239c3a043fd940f63f