### PR TITLE
Add configurable temp/humidity ranges

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -1,1 +1,2 @@
 source "components/ui/Kconfig"
+source "components/settings/Kconfig"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ cp sdkconfig.defaults sdkconfig
 
 Modify the copied file with `idf.py menuconfig` if your board needs different options. You can maintain multiple configuration files (for example, `sdkconfig.nodemcu`) and select one with `idf.py -DSDKCONFIG=<file> build`.
 
+### Temperature and Humidity Ranges
+
+Thresholds for activating the relay are stored in NVS and can be configured
+with `idf.py menuconfig` under **Settings**. They may also be changed at runtime
+using the `settings_set_temp_range` and `settings_set_hum_range` APIs.
+
 ## Roadmap
 
 - Sensor integration for monitoring enclosure conditions

--- a/components/README.md
+++ b/components/README.md
@@ -7,3 +7,4 @@ This project defines several custom components:
 - **relay** - simple GPIO-controlled relay driver.
 - **logger** - saves sensor readings to SPIFFS.
 - **ui** - minimal LVGL interface displaying temperature and humidity.
+- **settings** - stores configurable temperature and humidity ranges in NVS.

--- a/components/settings/CMakeLists.txt
+++ b/components/settings/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "settings.c" INCLUDE_DIRS "include" REQUIRES nvs_flash)

--- a/components/settings/Kconfig
+++ b/components/settings/Kconfig
@@ -1,0 +1,14 @@
+menu "Settings"
+config SETTINGS_TEMP_MIN
+    float "Minimum temperature (C)"
+    default 20.0
+config SETTINGS_TEMP_MAX
+    float "Maximum temperature (C)"
+    default 30.0
+config SETTINGS_HUM_MIN
+    float "Minimum humidity (%)"
+    default 40.0
+config SETTINGS_HUM_MAX
+    float "Maximum humidity (%)"
+    default 60.0
+endmenu

--- a/components/settings/include/settings.h
+++ b/components/settings/include/settings.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "esp_err.h"
+
+esp_err_t settings_init(void);
+esp_err_t settings_get_temp_range(float *min_c, float *max_c);
+esp_err_t settings_set_temp_range(float min_c, float max_c);
+esp_err_t settings_get_hum_range(float *min_percent, float *max_percent);
+esp_err_t settings_set_hum_range(float min_percent, float max_percent);

--- a/components/settings/settings.c
+++ b/components/settings/settings.c
@@ -1,0 +1,84 @@
+#include "settings.h"
+#include "nvs.h"
+#include "nvs_flash.h"
+#include "esp_log.h"
+
+static const char *TAG = "settings";
+static nvs_handle_t handle;
+
+// Default values via menuconfig
+#ifndef CONFIG_SETTINGS_TEMP_MIN
+#define CONFIG_SETTINGS_TEMP_MIN 20.0
+#endif
+#ifndef CONFIG_SETTINGS_TEMP_MAX
+#define CONFIG_SETTINGS_TEMP_MAX 30.0
+#endif
+#ifndef CONFIG_SETTINGS_HUM_MIN
+#define CONFIG_SETTINGS_HUM_MIN 40.0
+#endif
+#ifndef CONFIG_SETTINGS_HUM_MAX
+#define CONFIG_SETTINGS_HUM_MAX 60.0
+#endif
+
+esp_err_t settings_init(void)
+{
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "NVS init failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    ret = nvs_open("cfg", NVS_READWRITE, &handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "NVS open failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    return ESP_OK;
+}
+
+static esp_err_t get_value(const char *key, float def_val, float *out)
+{
+    int32_t val = (int32_t)(def_val * 10);
+    nvs_get_i32(handle, key, &val);
+    if (out) *out = val / 10.0f;
+    return ESP_OK;
+}
+
+static esp_err_t set_value(const char *key, float val)
+{
+    int32_t iv = (int32_t)(val * 10);
+    esp_err_t ret = nvs_set_i32(handle, key, iv);
+    if (ret == ESP_OK) nvs_commit(handle);
+    return ret;
+}
+
+esp_err_t settings_get_temp_range(float *min_c, float *max_c)
+{
+    get_value("tmin", CONFIG_SETTINGS_TEMP_MIN, min_c);
+    get_value("tmax", CONFIG_SETTINGS_TEMP_MAX, max_c);
+    return ESP_OK;
+}
+
+esp_err_t settings_set_temp_range(float min_c, float max_c)
+{
+    set_value("tmin", min_c);
+    set_value("tmax", max_c);
+    return ESP_OK;
+}
+
+esp_err_t settings_get_hum_range(float *min_p, float *max_p)
+{
+    get_value("hmin", CONFIG_SETTINGS_HUM_MIN, min_p);
+    get_value("hmax", CONFIG_SETTINGS_HUM_MAX, max_p);
+    return ESP_OK;
+}
+
+esp_err_t settings_set_hum_range(float min_p, float max_p)
+{
+    set_value("hmin", min_p);
+    set_value("hmax", max_p);
+    return ESP_OK;
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,3 +25,11 @@ Parallel displays require wiring the D0–D7 data lines and the control pins
 
 You may also override the resolution at runtime by passing a
 `ui_screen_config_t` structure to `ui_init`.
+
+## Adjusting Temperature and Humidity Ranges
+
+The relay controlling the heating or humidifying device switches based on
+configurable thresholds stored in NVS. Default values can be set in
+`menuconfig` under **Settings**. At runtime you can update the ranges over
+UART using the `settings_set_*` functions from a custom command handler or
+via `idf.py monitor`.

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,1 +1,1 @@
-idf_component_register(SRCS "main.c" INCLUDE_DIRS "." REQUIRES dht22 ds18b20 relay logger ui)
+idf_component_register(SRCS "main.c" INCLUDE_DIRS "." REQUIRES dht22 ds18b20 relay logger ui settings)

--- a/main/main.c
+++ b/main/main.c
@@ -9,6 +9,7 @@
 #include "relay.h"
 #include "logger.h"
 #include "ui.h"
+#include "settings.h"
 
 static const char *TAG = "main";
 
@@ -21,12 +22,20 @@ void app_main(void)
 {
     ESP_LOGI(TAG, "Hello Lizard Manager!");
 
+    settings_init();
     dht22_init(GPIO_NUM_4);
     ds18b20_init(GPIO_NUM_5);
     relay_init(GPIO_NUM_2);
     logger_init();
     esp_register_shutdown_handler(&cleanup);
     ui_init(NULL);
+
+    float temp_min = 0, temp_max = 0, hum_min = 0, hum_max = 0;
+    settings_get_temp_range(&temp_min, &temp_max);
+    settings_get_hum_range(&hum_min, &hum_max);
+    ESP_LOGI(TAG, "Temp range: %.1f-%.1fC Hum range: %.1f-%.1f%%", temp_min, temp_max, hum_min, hum_max);
+
+    bool relay_on = false;
 
     while (true) {
         float t1 = 0.0f, h1 = 0.0f, t2 = 0.0f;
@@ -35,6 +44,19 @@ void app_main(void)
         ESP_LOGI(TAG, "DHT22: %.1fC %.1f%%  DS18B20: %.1fC", t1, h1, t2);
         logger_log(t1, h1, t2);
         ui_set_values(t1, h1);
+
+        if ((t1 < temp_min) || (h1 < hum_min)) {
+            if (!relay_on) {
+                relay_set_state(true);
+                relay_on = true;
+            }
+        } else if ((t1 > temp_max) || (h1 > hum_max)) {
+            if (relay_on) {
+                relay_set_state(false);
+                relay_on = false;
+            }
+        }
+
         vTaskDelay(pdMS_TO_TICKS(5000));
     }
 


### PR DESCRIPTION
## Summary
- add settings component backed by NVS for storing temp/humidity ranges
- control relay in `main` using these settings
- document how to adjust thresholds via menuconfig or at runtime

## Testing
- `idf.py build` *(fails: command not found)*
- `idf.py -C tests build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e44622c508323a6666501df9e10bb