### PR TITLE
Mock hardware in tests

### DIFF
--- a/tests/main/CMakeLists.txt
+++ b/tests/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "test_main.c"
                        INCLUDE_DIRS "."
-                       REQUIRES unity dht22 ds18b20 relay)
+                       REQUIRES unity)

--- a/tests/main/test_main.c
+++ b/tests/main/test_main.c
@@ -1,10 +1,77 @@
 #include "unity.h"
-#include "dht22.h"
-#include "ds18b20.h"
-#include "relay.h"
+#include "esp_err.h"
 #include "driver/gpio.h"
+#include <stdbool.h>
 
-void setUp(void) {}
+/*
+ * Simple simulation layer for sensor and relay APIs. The real hardware
+ * drivers are not used during unit testing. Instead we provide lightweight
+ * implementations that mimic their behaviour so tests can run on the host
+ * without needing an ESP device attached.
+ */
+
+static bool dht22_initialized;
+static bool ds18b20_initialized;
+static bool relay_initialized;
+static bool relay_state;
+
+esp_err_t dht22_init(gpio_num_t pin)
+{
+    (void)pin;
+    dht22_initialized = true;
+    return ESP_OK;
+}
+
+esp_err_t dht22_read(float *temperature, float *humidity)
+{
+    if (!dht22_initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (temperature) *temperature = 23.0f;
+    if (humidity) *humidity = 50.0f;
+    return ESP_OK;
+}
+
+esp_err_t ds18b20_init(gpio_num_t pin)
+{
+    (void)pin;
+    ds18b20_initialized = true;
+    return ESP_OK;
+}
+
+esp_err_t ds18b20_read(float *temperature)
+{
+    if (!ds18b20_initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (temperature) *temperature = 26.0f;
+    return ESP_OK;
+}
+
+esp_err_t relay_init(gpio_num_t pin)
+{
+    (void)pin;
+    relay_initialized = true;
+    relay_state = false;
+    return ESP_OK;
+}
+
+esp_err_t relay_set_state(bool on)
+{
+    if (!relay_initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    relay_state = on;
+    return ESP_OK;
+}
+
+void setUp(void)
+{
+    dht22_initialized = false;
+    ds18b20_initialized = false;
+    relay_initialized = false;
+    relay_state = false;
+}
 void tearDown(void) {}
 
 void test_dht22_read(void)
@@ -43,6 +110,11 @@ void test_relay_set_state(void)
     TEST_ASSERT_EQUAL(ESP_OK, relay_set_state(false));
 }
 
+void test_relay_set_state_invalid_state(void)
+{
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, relay_set_state(true));
+}
+
 void app_main(void)
 {
     UNITY_BEGIN();
@@ -51,5 +123,6 @@ void app_main(void)
     RUN_TEST(test_ds18b20_read);
     RUN_TEST(test_ds18b20_invalid_state);
     RUN_TEST(test_relay_set_state);
+    RUN_TEST(test_relay_set_state_invalid_state);
     UNITY_END();
 }


### PR DESCRIPTION
## Summary
- update unit tests with mock sensor and relay implementations
- add relay negative test case
- drop hardware components from test build

## Testing
- `idf.py -C tests build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4b0956948323819078062cd7bcca