### PR TITLE
Add LVGL component via ESP registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Lizard Manager is an ESP-IDF based project for monitoring and controlling a rept
 1. Install ESP-IDF and set up the environment.
 2. Run `idf.py set-target esp32` once for the project.
 3. Build the firmware with `idf.py build`.
+   The UI component pulls LVGL version 8.3 automatically from Espressif's
+   component registry during this step.
 4. Flash and monitor with `idf.py flash monitor`.
 
 ## Configuration

--- a/components/ui/idf_component.yml
+++ b/components/ui/idf_component.yml
@@ -1,0 +1,3 @@
+version: "1.0.0"
+dependencies:
+  espressif/lvgl: "~8.3.0"


### PR DESCRIPTION
## Summary
- pull lvgl from Espressif component registry
- document automatic LVGL download during build

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e4d85980883239a83f6b4448a81fc