### PR TITLE
Add hardware setup docs and improve contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,12 @@ project consistent and easy to maintain.
 
 ## Pull Request Process
 
-1. Fork the repository and create a new branch for your feature or fix.
-2. Make your changes with clear, descriptive commit messages.
-3. Ensure that no unrelated changes are included in the branch.
-4. Open a pull request against the `main` branch and describe your changes.
-5. One or more maintainers will review your submission and may request updates.
+1. Fork the repository and create a dedicated branch for your changes.
+2. Make your edits with clear, descriptive commit messages.
+3. Keep commits focused on a single topic.
+4. Push the branch to your fork and open a pull request against `main`.
+5. Describe the motivation for the change and reference related issues if applicable.
+6. One or more maintainers will review your submission and may request updates.
 
 ## Testing Requirements
 
@@ -35,3 +36,9 @@ idf.py -C tests build
 ```
 
 The CI workflow will run the same commands automatically on GitHub Actions.
+
+## Good Practices
+
+* Format new code consistently with the surrounding files.
+* Include documentation or unit tests when adding features.
+* Rebase your branch if it falls behind `main` to simplify review.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Lizard Manager is an ESP-IDF based project for monitoring and controlling a rept
 - `config/` - configuration files
 - `docs/` - project documentation
 - Wiring recommendations are available in `docs/pin_assignments.md`
+- A step-by-step hardware guide can be found in `docs/hardware_setup.md`
 
 ## Prerequisites
 

--- a/docs/hardware_setup.md
+++ b/docs/hardware_setup.md
@@ -1,0 +1,38 @@
+# Hardware Setup
+
+This guide summarizes how to wire the sensors, relay and power connections for a basic Lizard Manager installation.
+
+## Required Parts
+
+- ESP32 development board (DevKitC or equivalent)
+- DHT22 humidity/temperature sensor
+- DS18B20 temperature probe
+- Single-channel relay module
+- 5&nbsp;V power supply for the ESP32 and peripherals
+- Assorted jumper wires
+
+## Wiring Overview
+
+The default firmware expects the following GPIO assignments:
+
+| Device  | ESP32 GPIO | Notes                                  |
+|---------|------------|----------------------------------------|
+| DHT22   | GPIO4      | Add a 4.7&nbsp;kΩ pull-up resistor     |
+| DS18B20 | GPIO5      | Requires a 4.7&nbsp;kΩ pull-up         |
+| Relay   | GPIO2      | Module should accept 3.3&nbsp;V logic  |
+
+Refer to `docs/pin_assignments.md` for display pins and optional peripherals.
+
+### Power Connections
+
+Feed 5&nbsp;V to the board's VIN/5&nbsp;V pin and connect GND to the power supply ground.
+Sensors draw 3.3&nbsp;V from the ESP32; do not exceed this voltage on any GPIO pin.
+Use a separate supply for high-current loads if necessary.
+
+### Relay Wiring
+
+The relay module switches the heating or lighting device. Connect the relay's
+IN pin to GPIO2 and power the module according to its specifications.
+Route mains wiring away from the ESP32 and ensure the relay is rated for the
+load you intend to control.
+


### PR DESCRIPTION
## Summary
- document power connections and wiring in `hardware_setup.md`
- expand PR guidelines and best practices in `CONTRIBUTING.md`
- reference new docs from the README

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5b7e52808323944a5e25df733d44