### PR TITLE
Move requires_init tests ahead of initialization

### DIFF
--- a/tests/main/test_main.c
+++ b/tests/main/test_main.c
@@ -78,15 +78,18 @@ void test_logger_write_temp_fs(void)
 void app_main(void)
 {
     UNITY_BEGIN();
+    RUN_TEST(test_dht22_requires_init);
     RUN_TEST(test_dht22_init_invalid_pin);
     RUN_TEST(test_dht22_init_valid_pin);
-    RUN_TEST(test_dht22_requires_init);
+
+    RUN_TEST(test_ds18b20_requires_init);
     RUN_TEST(test_ds18b20_init_invalid_pin);
     RUN_TEST(test_ds18b20_init_valid_pin);
-    RUN_TEST(test_ds18b20_requires_init);
+
+    RUN_TEST(test_relay_requires_init);
     RUN_TEST(test_relay_init_invalid_pin);
     RUN_TEST(test_relay_basic);
-    RUN_TEST(test_relay_requires_init);
+
     RUN_TEST(test_logger_requires_init);
     RUN_TEST(test_logger_write_temp_fs);
     UNITY_END();


### PR DESCRIPTION
## Summary
- ensure `requires_init` tests run before any initialization tests

## Testing
- `idf.py -C tests build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6eff2b0c8323a21385252e1f3ecf