### PR TITLE
Add feeding logs and reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A small LVGL-based UI shows the current temperature and humidity on the
 connected display. Use `idf.py menuconfig` to select an SPI or parallel
 interface and to set the default screen resolution. The interface updates every
 five seconds with the latest values from the sensors.
+The screen also shows the last feeding date and days until the next reminder.
 
 ## Contributing
 

--- a/components/README.md
+++ b/components/README.md
@@ -10,3 +10,4 @@ This project defines several custom components:
 - **ui** - minimal LVGL interface displaying temperature and humidity.
 - **settings** - stores configurable temperature and humidity ranges in NVS.
 - **genetics** - stores species and morph definitions and basic trait utilities.
+- **feeding** - records feeding events and stores reminder settings.

--- a/components/feeding/CMakeLists.txt
+++ b/components/feeding/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "feeding.c" INCLUDE_DIRS "include" REQUIRES nvs_flash)

--- a/components/feeding/Kconfig
+++ b/components/feeding/Kconfig
@@ -1,0 +1,5 @@
+menu "Feeding"
+config FEEDING_INTERVAL_DAYS
+    int "Default feeding interval (days)"
+    default 7
+endmenu

--- a/components/feeding/feeding.c
+++ b/components/feeding/feeding.c
@@ -1,0 +1,117 @@
+#include "feeding.h"
+#include "esp_log.h"
+#include "esp_spiffs.h"
+#include "nvs.h"
+#include "nvs_flash.h"
+#include <stdio.h>
+#include <string.h>
+
+static const char *TAG = "feeding";
+static FILE *log_file = NULL;
+static nvs_handle_t nvs_handle;
+static int interval_days = 0; // default loaded from menuconfig
+
+#ifndef CONFIG_FEEDING_INTERVAL_DAYS
+#define CONFIG_FEEDING_INTERVAL_DAYS 7
+#endif
+
+esp_err_t feeding_init(void)
+{
+    esp_vfs_spiffs_conf_t conf = {
+        .base_path = "/spiffs",
+        .partition_label = NULL,
+        .max_files = 5,
+        .format_if_mount_failed = true
+    };
+    ESP_ERROR_CHECK(esp_vfs_spiffs_register(&conf));
+
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    if (ret != ESP_OK) return ret;
+
+    ret = nvs_open("feed", NVS_READWRITE, &nvs_handle);
+    if (ret != ESP_OK) return ret;
+
+    int32_t days = CONFIG_FEEDING_INTERVAL_DAYS;
+    nvs_get_i32(nvs_handle, "interval", &days);
+    interval_days = days;
+
+    log_file = fopen("/spiffs/feedings.csv", "a+");
+    if (!log_file) {
+        ESP_LOGE(TAG, "Failed to open feedings.csv");
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+esp_err_t feeding_log(time_t timestamp, const char *prey, float weight_change, bool refusal)
+{
+    if (!log_file) return ESP_ERR_INVALID_STATE;
+    fprintf(log_file, "%ld,%s,%.1f,%d\n", (long)timestamp, prey ? prey : "", weight_change, refusal ? 1 : 0);
+    fflush(log_file);
+    nvs_set_i64(nvs_handle, "last", (int64_t)timestamp);
+    nvs_commit(nvs_handle);
+    return ESP_OK;
+}
+
+esp_err_t feeding_get_last(time_t *timestamp, char *prey, size_t prey_len, float *weight_change, bool *refusal)
+{
+    if (!log_file) return ESP_ERR_INVALID_STATE;
+    fseek(log_file, 0, SEEK_END);
+    long size = ftell(log_file);
+    if (size <= 0) return ESP_ERR_NOT_FOUND;
+
+    long pos = size;
+    int newline = 0;
+    while (pos > 0) {
+        pos--;
+        fseek(log_file, pos, SEEK_SET);
+        int c = fgetc(log_file);
+        if (c == '\n') {
+            if (newline) break;
+            newline = 1;
+        }
+    }
+    char line[128];
+    fgets(line, sizeof(line), log_file);
+    time_t ts; char prey_buf[64]; float wt; int ref;
+    sscanf(line, "%ld,%63[^,],%f,%d", (long *)&ts, prey_buf, &wt, &ref);
+    if (timestamp) *timestamp = ts;
+    if (prey && prey_len) strncpy(prey, prey_buf, prey_len - 1), prey[prey_len - 1] = '\0';
+    if (weight_change) *weight_change = wt;
+    if (refusal) *refusal = ref != 0;
+    return ESP_OK;
+}
+
+esp_err_t feeding_set_interval_days(int days)
+{
+    interval_days = days;
+    nvs_set_i32(nvs_handle, "interval", days);
+    nvs_commit(nvs_handle);
+    return ESP_OK;
+}
+
+esp_err_t feeding_get_interval_days(int *days)
+{
+    if (days) *days = interval_days;
+    return ESP_OK;
+}
+
+static time_t get_last_timestamp(void)
+{
+    int64_t val = 0;
+    nvs_get_i64(nvs_handle, "last", &val);
+    return (time_t)val;
+}
+
+bool feeding_overdue(int *days_until)
+{
+    time_t last = get_last_timestamp();
+    time_t now = time(NULL);
+    int diff = (int)((now - last) / 86400);
+    if (days_until) *days_until = interval_days - diff;
+    return diff >= interval_days;
+}

--- a/components/feeding/include/feeding.h
+++ b/components/feeding/include/feeding.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "esp_err.h"
+#include <stdbool.h>
+#include <time.h>
+
+esp_err_t feeding_init(void);
+esp_err_t feeding_log(time_t timestamp, const char *prey, float weight_change, bool refusal);
+esp_err_t feeding_get_last(time_t *timestamp, char *prey, size_t prey_len, float *weight_change, bool *refusal);
+esp_err_t feeding_set_interval_days(int days);
+esp_err_t feeding_get_interval_days(int *days);
+bool feeding_overdue(int *days_until);

--- a/components/ui/include/ui.h
+++ b/components/ui/include/ui.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "lvgl.h"
+#include <time.h>
 
 typedef struct {
     int hor_res;
@@ -8,3 +9,4 @@ typedef struct {
 
 void ui_init(const ui_screen_config_t *config); // pass NULL to use defaults
 void ui_set_values(float temp, float humidity);
+void ui_set_feeding(time_t last_feed, int days_until_next);

--- a/components/ui/ui.c
+++ b/components/ui/ui.c
@@ -14,6 +14,8 @@
 static const char *TAG = "ui";
 static lv_obj_t *temp_label;
 static lv_obj_t *hum_label;
+static lv_obj_t *feed_label;
+static lv_obj_t *reminder_label;
 static lv_disp_draw_buf_t draw_buf;
 static lv_color_t *buf1;
 #define LV_TICK_PERIOD_MS 2
@@ -151,10 +153,16 @@ void ui_init(const ui_screen_config_t *config)
 
     temp_label = lv_label_create(lv_scr_act());
     hum_label = lv_label_create(lv_scr_act());
+    feed_label = lv_label_create(lv_scr_act());
+    reminder_label = lv_label_create(lv_scr_act());
     lv_obj_align(temp_label, LV_ALIGN_TOP_MID, 0, 10);
     lv_obj_align(hum_label, LV_ALIGN_TOP_MID, 0, 30);
+    lv_obj_align(feed_label, LV_ALIGN_TOP_MID, 0, 50);
+    lv_obj_align(reminder_label, LV_ALIGN_TOP_MID, 0, 70);
     lv_label_set_text(temp_label, "Temp: --.-C");
     lv_label_set_text(hum_label, "Humidity: --.-%");
+    lv_label_set_text(feed_label, "Last feed: --");
+    lv_label_set_text(reminder_label, "Next feed: --");
     ESP_LOGI(TAG, "UI initialized (%dx%d)", hor_res, ver_res);
 }
 
@@ -166,5 +174,21 @@ void ui_set_values(float temp, float humidity)
     lv_label_set_text(temp_label, buf);
     snprintf(buf, sizeof(buf), "Humidity: %.1f%%", humidity);
     lv_label_set_text(hum_label, buf);
+    lv_timer_handler();
+}
+
+void ui_set_feeding(time_t last_feed, int days_until_next)
+{
+    if (!feed_label || !reminder_label) return;
+    char buf[64];
+    if (last_feed > 0) {
+        struct tm *tm = localtime(&last_feed);
+        strftime(buf, sizeof(buf), "Last feed: %Y-%m-%d", tm);
+    } else {
+        snprintf(buf, sizeof(buf), "Last feed: --");
+    }
+    lv_label_set_text(feed_label, buf);
+    snprintf(buf, sizeof(buf), "Next feed: %d day(s)", days_until_next);
+    lv_label_set_text(reminder_label, buf);
     lv_timer_handler();
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 This directory stores project documentation.
 
 See `pin_assignments.md` for wiring instructions. See `french_eu_reptile_regs.md` for a summary of French and EU regulations on amateur reptile keeping. For details on registering your animals, read `register_animal.md`.
+Feeding logs are documented in `feeding.md`.
 
 ## Required Hardware
 

--- a/docs/feeding.md
+++ b/docs/feeding.md
@@ -1,0 +1,10 @@
+# Feeding Logs
+
+The firmware stores meal history in `/spiffs/feedings.csv`. Each line contains:
+
+- Unix timestamp (seconds)
+- Prey description
+- Weight change in grams
+- `1` if the animal refused the meal, otherwise `0`
+
+Use the `feeding` component APIs to record feedings and to configure reminder intervals.

--- a/tests/main/test_main.c
+++ b/tests/main/test_main.c
@@ -5,6 +5,7 @@
 #include "ds18b20.h"
 #include "relay.h"
 #include "logger.h"
+#include "feeding.h"
 
 void setUp(void) {}
 void tearDown(void) {}
@@ -75,6 +76,19 @@ void test_logger_write_temp_fs(void)
     TEST_ASSERT_EQUAL_STRING("1.0,2.0,3.0\n", line);
 }
 
+void test_feeding_log(void)
+{
+    TEST_ASSERT_EQUAL(ESP_OK, feeding_init());
+    time_t now = 123456;
+    TEST_ASSERT_EQUAL(ESP_OK, feeding_log(now, "mouse", 4.5f, false));
+    time_t ts = 0; char prey[16] = {0}; float wt = 0.0f; bool ref = true;
+    TEST_ASSERT_EQUAL(ESP_OK, feeding_get_last(&ts, prey, sizeof(prey), &wt, &ref));
+    TEST_ASSERT_EQUAL(now, ts);
+    TEST_ASSERT_EQUAL_STRING("mouse", prey);
+    TEST_ASSERT_FLOAT_WITHIN(0.1f, 4.5f, wt);
+    TEST_ASSERT_FALSE(ref);
+}
+
 void app_main(void)
 {
     UNITY_BEGIN();
@@ -92,5 +106,6 @@ void app_main(void)
 
     RUN_TEST(test_logger_requires_init);
     RUN_TEST(test_logger_write_temp_fs);
+    RUN_TEST(test_feeding_log);
     UNITY_END();
 }


### PR DESCRIPTION
## Summary
- log reptile feedings in new `feeding` component
- allow configuring feeding interval in NVS
- show last feeding and next reminder in the LVGL UI
- document feeding logs and update component list
- unit test feeding logging

## Testing
- `idf.py -C tests build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e8ae773fc832385e53f7b19a80e8f