### PR TITLE
Add enclosure management model

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ using the `settings_set_temp_range` and `settings_set_hum_range` APIs.
 - Control loops to maintain temperature and humidity
 - Simple user interface for configuration and monitoring
 - Data logging and analytics features
+- Enclosure records with maintenance reminders
 
 ## Logging
 

--- a/components/animals/animals.c
+++ b/components/animals/animals.c
@@ -21,17 +21,38 @@ static esp_err_t load_file(void)
         char *saveptr = NULL;
         char *token = strtok_r(line, ",\n", &saveptr);
         if (!token) continue;
-        strncpy(animals[animal_count].id, token, sizeof(animals[animal_count].id)-1);
+        strncpy(animals[animal_count].id, token,
+                sizeof(animals[animal_count].id) - 1);
         token = strtok_r(NULL, ",\n", &saveptr);
-        if (token) strncpy(animals[animal_count].species, token, sizeof(animals[animal_count].species)-1);
+        if (token) {
+            strncpy(animals[animal_count].species, token,
+                    sizeof(animals[animal_count].species) - 1);
+        }
         token = strtok_r(NULL, ",\n", &saveptr);
-        if (token) strncpy(animals[animal_count].sex, token, sizeof(animals[animal_count].sex)-1);
+        if (token) {
+            strncpy(animals[animal_count].sex, token,
+                    sizeof(animals[animal_count].sex) - 1);
+        }
         token = strtok_r(NULL, ",\n", &saveptr);
-        if (token) strncpy(animals[animal_count].birthdate, token, sizeof(animals[animal_count].birthdate)-1);
+        if (token) {
+            strncpy(animals[animal_count].birthdate, token,
+                    sizeof(animals[animal_count].birthdate) - 1);
+        }
         token = strtok_r(NULL, ",\n", &saveptr);
-        if (token) strncpy(animals[animal_count].legal_status, token, sizeof(animals[animal_count].legal_status)-1);
+        if (token) {
+            strncpy(animals[animal_count].legal_status, token,
+                    sizeof(animals[animal_count].legal_status) - 1);
+        }
+        token = strtok_r(NULL, ",\n", &saveptr);
+        if (token) {
+            strncpy(animals[animal_count].photos, token,
+                    sizeof(animals[animal_count].photos) - 1);
+        }
         token = strtok_r(NULL, "\n", &saveptr);
-        if (token) strncpy(animals[animal_count].photos, token, sizeof(animals[animal_count].photos)-1);
+        if (token) {
+            strncpy(animals[animal_count].enclosure_id, token,
+                    sizeof(animals[animal_count].enclosure_id) - 1);
+        }
         animal_count++;
     }
     fclose(f);
@@ -46,13 +67,14 @@ static esp_err_t save_file(void)
         return ESP_FAIL;
     }
     for (size_t i = 0; i < animal_count; ++i) {
-        fprintf(f, "%s,%s,%s,%s,%s,%s\n",
+        fprintf(f, "%s,%s,%s,%s,%s,%s,%s\n",
                 animals[i].id,
                 animals[i].species,
                 animals[i].sex,
                 animals[i].birthdate,
                 animals[i].legal_status,
-                animals[i].photos);
+                animals[i].photos,
+                animals[i].enclosure_id);
     }
     fclose(f);
     return ESP_OK;

--- a/components/animals/include/animals.h
+++ b/components/animals/include/animals.h
@@ -11,6 +11,7 @@ typedef struct {
     char birthdate[11];
     char legal_status[32];
     char photos[128];
+    char enclosure_id[16];
 } animal_t;
 
 esp_err_t animals_init(void);

--- a/components/enclosures/CMakeLists.txt
+++ b/components/enclosures/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "enclosures.c" INCLUDE_DIRS "include" REQUIRES esp_spiffs nvs_flash)

--- a/components/enclosures/enclosures.c
+++ b/components/enclosures/enclosures.c
@@ -1,0 +1,183 @@
+#include "enclosures.h"
+#include "esp_log.h"
+#include "esp_spiffs.h"
+#include "nvs.h"
+#include "nvs_flash.h"
+#include <string.h>
+#include <stdio.h>
+
+static const char *TAG = "enclosures";
+static enclosure_t enclosures[ENCLOSURES_MAX];
+static size_t enclosure_count = 0;
+static bool initialized = false;
+
+static esp_err_t load_file(void)
+{
+    FILE *f = fopen("/spiffs/enclosures.csv", "r");
+    if (!f) {
+        return ESP_OK;
+    }
+    char line[256];
+    while (fgets(line, sizeof(line), f) && enclosure_count < ENCLOSURES_MAX) {
+        char *saveptr = NULL;
+        char *token = strtok_r(line, ",\n", &saveptr);
+        if (!token) continue;
+        strncpy(enclosures[enclosure_count].id, token,
+                sizeof(enclosures[enclosure_count].id) - 1);
+        token = strtok_r(NULL, ",\n", &saveptr);
+        if (token) strncpy(enclosures[enclosure_count].name, token,
+                           sizeof(enclosures[enclosure_count].name) - 1);
+        token = strtok_r(NULL, ",\n", &saveptr);
+        if (token) strncpy(enclosures[enclosure_count].location, token,
+                           sizeof(enclosures[enclosure_count].location) - 1);
+        token = strtok_r(NULL, ",\n", &saveptr);
+        if (token) enclosures[enclosure_count].temp_min = strtof(token, NULL);
+        token = strtok_r(NULL, ",\n", &saveptr);
+        if (token) enclosures[enclosure_count].temp_max = strtof(token, NULL);
+        token = strtok_r(NULL, ",\n", &saveptr);
+        if (token) enclosures[enclosure_count].hum_min = strtof(token, NULL);
+        token = strtok_r(NULL, ",\n", &saveptr);
+        if (token) enclosures[enclosure_count].hum_max = strtof(token, NULL);
+        token = strtok_r(NULL, ",\n", &saveptr);
+        if (token) strncpy(enclosures[enclosure_count].sensors, token,
+                           sizeof(enclosures[enclosure_count].sensors) - 1);
+        token = strtok_r(NULL, ",\n", &saveptr);
+        if (token) enclosures[enclosure_count].last_cleaning = strtol(token, NULL, 10);
+        token = strtok_r(NULL, ",\n", &saveptr);
+        if (token) enclosures[enclosure_count].cleaning_interval_days = atoi(token);
+        token = strtok_r(NULL, ",\n", &saveptr);
+        if (token) enclosures[enclosure_count].last_substrate = strtol(token, NULL, 10);
+        token = strtok_r(NULL, "\n", &saveptr);
+        if (token) enclosures[enclosure_count].substrate_interval_days = atoi(token);
+        enclosure_count++;
+    }
+    fclose(f);
+    return ESP_OK;
+}
+
+static esp_err_t save_file(void)
+{
+    FILE *f = fopen("/spiffs/enclosures.csv", "w");
+    if (!f) {
+        ESP_LOGE(TAG, "Failed to open enclosures.csv for write");
+        return ESP_FAIL;
+    }
+    for (size_t i = 0; i < enclosure_count; ++i) {
+        fprintf(f, "%s,%s,%s,%.1f,%.1f,%.1f,%.1f,%s,%ld,%d,%ld,%d\n",
+                enclosures[i].id,
+                enclosures[i].name,
+                enclosures[i].location,
+                enclosures[i].temp_min,
+                enclosures[i].temp_max,
+                enclosures[i].hum_min,
+                enclosures[i].hum_max,
+                enclosures[i].sensors,
+                (long)enclosures[i].last_cleaning,
+                enclosures[i].cleaning_interval_days,
+                (long)enclosures[i].last_substrate,
+                enclosures[i].substrate_interval_days);
+    }
+    fclose(f);
+    return ESP_OK;
+}
+
+esp_err_t enclosures_init(void)
+{
+    if (initialized) return ESP_OK;
+    esp_vfs_spiffs_conf_t conf = {
+        .base_path = "/spiffs",
+        .partition_label = NULL,
+        .max_files = 5,
+        .format_if_mount_failed = true
+    };
+    esp_err_t ret = esp_vfs_spiffs_register(&conf);
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "SPIFFS mount failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    if (ret != ESP_OK) return ret;
+    load_file();
+    initialized = true;
+    return ESP_OK;
+}
+
+static int find_index(const char *id)
+{
+    for (size_t i = 0; i < enclosure_count; ++i) {
+        if (strcmp(enclosures[i].id, id) == 0) return (int)i;
+    }
+    return -1;
+}
+
+esp_err_t enclosures_add(const enclosure_t *enc)
+{
+    if (!initialized || !enc) return ESP_ERR_INVALID_STATE;
+    if (enclosure_count >= ENCLOSURES_MAX) return ESP_ERR_NO_MEM;
+    if (find_index(enc->id) >= 0) return ESP_ERR_INVALID_ARG;
+    enclosures[enclosure_count++] = *enc;
+    return save_file();
+}
+
+esp_err_t enclosures_get(const char *id, enclosure_t *out)
+{
+    if (!initialized || !id || !out) return ESP_ERR_INVALID_ARG;
+    int idx = find_index(id);
+    if (idx < 0) return ESP_ERR_NOT_FOUND;
+    *out = enclosures[idx];
+    return ESP_OK;
+}
+
+esp_err_t enclosures_update(const enclosure_t *enc)
+{
+    if (!initialized || !enc) return ESP_ERR_INVALID_STATE;
+    int idx = find_index(enc->id);
+    if (idx < 0) return ESP_ERR_NOT_FOUND;
+    enclosures[idx] = *enc;
+    return save_file();
+}
+
+esp_err_t enclosures_remove(const char *id)
+{
+    if (!initialized || !id) return ESP_ERR_INVALID_ARG;
+    int idx = find_index(id);
+    if (idx < 0) return ESP_ERR_NOT_FOUND;
+    for (size_t i = idx; i < enclosure_count - 1; ++i) {
+        enclosures[i] = enclosures[i + 1];
+    }
+    enclosure_count--;
+    return save_file();
+}
+
+esp_err_t enclosures_list(enclosure_t *out, size_t max, size_t *count)
+{
+    if (!initialized || !out || !count) return ESP_ERR_INVALID_ARG;
+    size_t n = (enclosure_count < max) ? enclosure_count : max;
+    for (size_t i = 0; i < n; ++i) out[i] = enclosures[i];
+    *count = enclosure_count;
+    return ESP_OK;
+}
+
+static bool due_helper(time_t last, int interval, int *days_until)
+{
+    time_t now = time(NULL);
+    int diff = (int)((now - last) / 86400);
+    if (days_until) *days_until = interval - diff;
+    return diff >= interval;
+}
+
+bool enclosures_cleaning_due(const enclosure_t *enc, int *days_until)
+{
+    if (!enc) return false;
+    return due_helper(enc->last_cleaning, enc->cleaning_interval_days, days_until);
+}
+
+bool enclosures_substrate_due(const enclosure_t *enc, int *days_until)
+{
+    if (!enc) return false;
+    return due_helper(enc->last_substrate, enc->substrate_interval_days, days_until);
+}

--- a/components/enclosures/include/enclosures.h
+++ b/components/enclosures/include/enclosures.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "esp_err.h"
+#include <time.h>
+#include <stddef.h>
+
+#define ENCLOSURES_MAX 16
+
+typedef struct {
+    char id[16];
+    char name[32];
+    char location[32];
+    float temp_min;
+    float temp_max;
+    float hum_min;
+    float hum_max;
+    char sensors[64];
+    time_t last_cleaning;
+    int cleaning_interval_days;
+    time_t last_substrate;
+    int substrate_interval_days;
+} enclosure_t;
+
+esp_err_t enclosures_init(void);
+esp_err_t enclosures_add(const enclosure_t *enc);
+esp_err_t enclosures_get(const char *id, enclosure_t *out);
+esp_err_t enclosures_update(const enclosure_t *enc);
+esp_err_t enclosures_remove(const char *id);
+esp_err_t enclosures_list(enclosure_t *out, size_t max, size_t *count);
+bool enclosures_cleaning_due(const enclosure_t *enc, int *days_until);
+bool enclosures_substrate_due(const enclosure_t *enc, int *days_until);

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 This directory stores project documentation.
 
 See `pin_assignments.md` for wiring instructions. See `french_eu_reptile_regs.md` for a summary of French and EU regulations on amateur reptile keeping. For details on registering your animals, read `register_animal.md`.
-Feeding logs are documented in `feeding.md`. Health records are described in `health.md`.
+Feeding logs are documented in `feeding.md`. Health records are described in `health.md`. Information about managing terrariums is in `enclosures.md`.
 
 ## Required Hardware
 

--- a/docs/enclosures.md
+++ b/docs/enclosures.md
@@ -1,0 +1,19 @@
+# Enclosures
+
+The firmware keeps a list of terrariums in `/spiffs/enclosures.csv`. Each line stores:
+
+- Identifier
+- Name
+- Location description
+- Minimum and maximum temperature (C)
+- Minimum and maximum humidity (%)
+- Sensor node identifiers separated by colons
+- Unix timestamp of the last cleaning
+- Cleaning interval in days
+- Unix timestamp of the last substrate change
+- Substrate change interval in days
+
+Use the `enclosures` component APIs to manage this list. After calling
+`enclosures_init`, you can add or retrieve enclosures and check when
+cleaning or substrate changes are due with
+`enclosures_cleaning_due` and `enclosures_substrate_due`.

--- a/docs/register_animal.md
+++ b/docs/register_animal.md
@@ -8,6 +8,7 @@ The firmware keeps a record of each reptile in `/spiffs/animals.csv`. Every entr
 - Birth date (`YYYY-MM-DD`)
 - Legal status or permit info
 - Photo file names separated by colons
+- Enclosure identifier
 
 Use the `animals` component APIs to manage this list. After calling `animals_init`, you can add animals with `animals_add`, read them with `animals_get`, modify them with `animals_update`, and remove them with `animals_remove`.
 


### PR DESCRIPTION
## Summary
- link animals to specific enclosures
- track temperature/humidity ranges per terrarium via new `enclosures` component
- provide cleaning and substrate change reminders
- document new CSV fields and enclosure management

## Testing
- `idf.py build` *(fails: command not found)*
- `idf.py -C tests build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e9d62d4588323a1a672d2565f046b