### PR TITLE
Add stock management component

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -12,3 +12,4 @@ This project defines several custom components:
 - **genetics** - stores species and morph definitions and basic trait utilities.
 - **feeding** - records feeding events and stores reminder settings.
 - **health** - records weight, length and health events.
+- **stock** - tracks feeder insect inventory and expiration dates.

--- a/components/stock/CMakeLists.txt
+++ b/components/stock/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "stock.c" INCLUDE_DIRS "include" REQUIRES esp_spiffs)

--- a/components/stock/include/stock.h
+++ b/components/stock/include/stock.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "esp_err.h"
+#include <time.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#define STOCK_MAX 32
+
+typedef struct {
+    char name[32];
+    int quantity;
+    time_t expiration;
+} stock_item_t;
+
+esp_err_t stock_init(void);
+esp_err_t stock_add(const stock_item_t *item);
+esp_err_t stock_get(const char *name, stock_item_t *out);
+esp_err_t stock_update(const stock_item_t *item);
+esp_err_t stock_remove(const char *name);
+esp_err_t stock_list(stock_item_t *out, size_t max, size_t *count);
+bool stock_low(const char *name, int threshold);
+bool stock_expiring_soon(const char *name, time_t now, int days);

--- a/components/stock/stock.c
+++ b/components/stock/stock.c
@@ -1,0 +1,137 @@
+#include "stock.h"
+#include "esp_log.h"
+#include "esp_spiffs.h"
+#include <stdio.h>
+#include <string.h>
+
+static const char *TAG = "stock";
+
+static stock_item_t items[STOCK_MAX];
+static size_t item_count = 0;
+static bool initialized = false;
+
+static esp_err_t load_file(void)
+{
+    FILE *f = fopen("/spiffs/stock.csv", "r");
+    if (!f) return ESP_OK; // no file yet
+    char line[128];
+    while (fgets(line, sizeof(line), f) && item_count < STOCK_MAX) {
+        char *saveptr = NULL;
+        char *token = strtok_r(line, ",\n", &saveptr);
+        if (!token) continue;
+        strncpy(items[item_count].name, token,
+                sizeof(items[item_count].name) - 1);
+        token = strtok_r(NULL, ",\n", &saveptr);
+        if (token) items[item_count].quantity = atoi(token);
+        token = strtok_r(NULL, ",\n", &saveptr);
+        if (token) items[item_count].expiration = strtoll(token, NULL, 10);
+        item_count++;
+    }
+    fclose(f);
+    return ESP_OK;
+}
+
+static esp_err_t save_file(void)
+{
+    FILE *f = fopen("/spiffs/stock.csv", "w");
+    if (!f) {
+        ESP_LOGE(TAG, "Failed to open stock.csv for write");
+        return ESP_FAIL;
+    }
+    for (size_t i = 0; i < item_count; ++i) {
+        fprintf(f, "%s,%d,%lld\n", items[i].name, items[i].quantity,
+                (long long)items[i].expiration);
+    }
+    fclose(f);
+    return ESP_OK;
+}
+
+esp_err_t stock_init(void)
+{
+    if (initialized) return ESP_OK;
+    esp_vfs_spiffs_conf_t conf = {
+        .base_path = "/spiffs",
+        .partition_label = NULL,
+        .max_files = 5,
+        .format_if_mount_failed = true
+    };
+    esp_err_t ret = esp_vfs_spiffs_register(&conf);
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "SPIFFS mount failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    load_file();
+    initialized = true;
+    return ESP_OK;
+}
+
+static int find_index(const char *name)
+{
+    for (size_t i = 0; i < item_count; ++i) {
+        if (strcmp(items[i].name, name) == 0) return (int)i;
+    }
+    return -1;
+}
+
+esp_err_t stock_add(const stock_item_t *item)
+{
+    if (!initialized || !item) return ESP_ERR_INVALID_STATE;
+    if (item_count >= STOCK_MAX) return ESP_ERR_NO_MEM;
+    if (find_index(item->name) >= 0) return ESP_ERR_INVALID_ARG;
+    items[item_count++] = *item;
+    return save_file();
+}
+
+esp_err_t stock_get(const char *name, stock_item_t *out)
+{
+    if (!initialized || !name || !out) return ESP_ERR_INVALID_ARG;
+    int idx = find_index(name);
+    if (idx < 0) return ESP_ERR_NOT_FOUND;
+    *out = items[idx];
+    return ESP_OK;
+}
+
+esp_err_t stock_update(const stock_item_t *item)
+{
+    if (!initialized || !item) return ESP_ERR_INVALID_STATE;
+    int idx = find_index(item->name);
+    if (idx < 0) return ESP_ERR_NOT_FOUND;
+    items[idx] = *item;
+    return save_file();
+}
+
+esp_err_t stock_remove(const char *name)
+{
+    if (!initialized || !name) return ESP_ERR_INVALID_ARG;
+    int idx = find_index(name);
+    if (idx < 0) return ESP_ERR_NOT_FOUND;
+    for (size_t i = idx; i < item_count - 1; ++i) items[i] = items[i+1];
+    item_count--;
+    return save_file();
+}
+
+esp_err_t stock_list(stock_item_t *out, size_t max, size_t *count)
+{
+    if (!initialized || !out || !count) return ESP_ERR_INVALID_ARG;
+    size_t n = (item_count < max) ? item_count : max;
+    for (size_t i = 0; i < n; ++i) out[i] = items[i];
+    *count = item_count;
+    return ESP_OK;
+}
+
+bool stock_low(const char *name, int threshold)
+{
+    if (!initialized || !name) return false;
+    int idx = find_index(name);
+    if (idx < 0) return false;
+    return items[idx].quantity <= threshold;
+}
+
+bool stock_expiring_soon(const char *name, time_t now, int days)
+{
+    if (!initialized || !name) return false;
+    int idx = find_index(name);
+    if (idx < 0) return false;
+    time_t limit = now + (time_t)days * 86400;
+    return items[idx].expiration <= limit;
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 This directory stores project documentation.
 
 See `pin_assignments.md` for wiring instructions. See `french_eu_reptile_regs.md` for a summary of French and EU regulations on amateur reptile keeping. For details on registering your animals, read `register_animal.md`.
-Feeding logs are documented in `feeding.md`. Health records are described in `health.md`. Information about managing terrariums is in `enclosures.md`.
+Feeding logs are documented in `feeding.md`. Health records are described in `health.md`. Stock inventory is documented in `stock.md`. Information about managing terrariums is in `enclosures.md`.
 
 ## Required Hardware
 

--- a/docs/stock.md
+++ b/docs/stock.md
@@ -1,0 +1,10 @@
+# Stock Management
+
+The firmware stores inventory data in `/spiffs/stock.csv`. Each line contains:
+
+- Item name
+- Quantity (integer)
+- Expiration date as Unix timestamp
+
+Use the `stock` component APIs to add, update and query inventory items. Helper
+functions report when an item is below a quantity threshold or expiring soon.

--- a/tests/main/test_main.c
+++ b/tests/main/test_main.c
@@ -6,6 +6,7 @@
 #include "relay.h"
 #include "logger.h"
 #include "feeding.h"
+#include "stock.h"
 
 void setUp(void) {}
 void tearDown(void) {}
@@ -89,6 +90,21 @@ void test_feeding_log(void)
     TEST_ASSERT_FALSE(ref);
 }
 
+void test_stock_alerts(void)
+{
+    TEST_ASSERT_EQUAL(ESP_OK, stock_init());
+    stock_item_t item = {
+        .name = "crickets",
+        .quantity = 5,
+        .expiration = 1000
+    };
+    TEST_ASSERT_EQUAL(ESP_OK, stock_add(&item));
+    TEST_ASSERT_TRUE(stock_low("crickets", 10));
+    TEST_ASSERT_FALSE(stock_low("crickets", 4));
+    TEST_ASSERT_TRUE(stock_expiring_soon("crickets", 900, 2));
+    TEST_ASSERT_FALSE(stock_expiring_soon("crickets", 900, 0));
+}
+
 void app_main(void)
 {
     UNITY_BEGIN();
@@ -107,5 +123,6 @@ void app_main(void)
     RUN_TEST(test_logger_requires_init);
     RUN_TEST(test_logger_write_temp_fs);
     RUN_TEST(test_feeding_log);
+    RUN_TEST(test_stock_alerts);
     UNITY_END();
 }


### PR DESCRIPTION
## Summary
- create `components/stock` for managing feeder insect inventory
- document stock usage and add to component lists
- add tests verifying stock alerts

## Testing
- `idf.py -C tests build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7032d0408323af237c0f74528179