### PR TITLE
Add authentication and audit trail

### DIFF
--- a/components/audit/CMakeLists.txt
+++ b/components/audit/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "audit.c" INCLUDE_DIRS "include")

--- a/components/audit/audit.c
+++ b/components/audit/audit.c
@@ -1,0 +1,48 @@
+#include "audit.h"
+#include "esp_spiffs.h"
+#include "esp_log.h"
+#include <stdio.h>
+#include <time.h>
+
+static const char *TAG = "audit";
+static FILE *audit_file = NULL;
+
+esp_err_t audit_init(void)
+{
+    esp_vfs_spiffs_conf_t conf = {
+        .base_path = "/spiffs",
+        .partition_label = NULL,
+        .max_files = 5,
+        .format_if_mount_failed = true
+    };
+    esp_err_t ret = esp_vfs_spiffs_register(&conf);
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "SPIFFS mount failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    audit_file = fopen("/spiffs/audit.csv", "a");
+    if (!audit_file) {
+        ESP_LOGE(TAG, "Failed to open audit.csv");
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}
+
+esp_err_t audit_log(const char *username, const char *action)
+{
+    if (!audit_file) return ESP_ERR_INVALID_STATE;
+    time_t now = time(NULL);
+    fprintf(audit_file, "%ld,%s,%s\n", (long)now,
+            username ? username : "", action ? action : "");
+    fflush(audit_file);
+    return ESP_OK;
+}
+
+void audit_close(void)
+{
+    if (audit_file) {
+        fflush(audit_file);
+        fclose(audit_file);
+        audit_file = NULL;
+    }
+}

--- a/components/audit/include/audit.h
+++ b/components/audit/include/audit.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+esp_err_t audit_init(void);
+esp_err_t audit_log(const char *username, const char *action);
+void audit_close(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/auth/CMakeLists.txt
+++ b/components/auth/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "auth.c" INCLUDE_DIRS "include" REQUIRES mbedtls)

--- a/components/auth/auth.c
+++ b/components/auth/auth.c
@@ -1,0 +1,147 @@
+#include "auth.h"
+#include "esp_spiffs.h"
+#include "esp_log.h"
+#include "mbedtls/sha256.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+#include <time.h>
+
+#define AUTH_MAX_USERS 8
+
+static const char *TAG = "auth";
+
+typedef struct {
+    char username[32];
+    char pass_hash[65];
+    auth_role_t role;
+} user_t;
+
+static user_t users[AUTH_MAX_USERS];
+static size_t user_count = 0;
+static bool initialized = false;
+static FILE *user_file = NULL;
+
+static const char *role_to_str(auth_role_t role)
+{
+    switch (role) {
+    case AUTH_ROLE_OWNER: return "owner";
+    case AUTH_ROLE_CARETAKER: return "caretaker";
+    case AUTH_ROLE_VET: return "vet";
+    default: return "unknown";
+    }
+}
+
+static auth_role_t str_to_role(const char *str)
+{
+    if (strcmp(str, "owner") == 0) return AUTH_ROLE_OWNER;
+    if (strcmp(str, "caretaker") == 0) return AUTH_ROLE_CARETAKER;
+    if (strcmp(str, "vet") == 0) return AUTH_ROLE_VET;
+    return AUTH_ROLE_UNKNOWN;
+}
+
+static void sha256_hex(const char *data, char out[65])
+{
+    unsigned char hash[32];
+    mbedtls_sha256_context ctx;
+    mbedtls_sha256_init(&ctx);
+    mbedtls_sha256_starts(&ctx, 0);
+    mbedtls_sha256_update(&ctx, (const unsigned char *)data, strlen(data));
+    mbedtls_sha256_finish(&ctx, hash);
+    mbedtls_sha256_free(&ctx);
+    for (int i = 0; i < 32; ++i) sprintf(out + i * 2, "%02x", hash[i]);
+    out[64] = '\0';
+}
+
+static esp_err_t save_file(void)
+{
+    if (!user_file) {
+        user_file = fopen("/spiffs/users.csv", "w");
+    } else {
+        freopen("/spiffs/users.csv", "w", user_file);
+    }
+    if (!user_file) {
+        ESP_LOGE(TAG, "Failed to open users.csv for write");
+        return ESP_FAIL;
+    }
+    for (size_t i = 0; i < user_count; ++i) {
+        fprintf(user_file, "%s,%s,%s\n", users[i].username, users[i].pass_hash,
+                role_to_str(users[i].role));
+    }
+    fflush(user_file);
+    return ESP_OK;
+}
+
+static esp_err_t load_file(void)
+{
+    user_file = fopen("/spiffs/users.csv", "a+");
+    if (!user_file) {
+        ESP_LOGE(TAG, "Failed to open users.csv");
+        return ESP_FAIL;
+    }
+    rewind(user_file);
+    char line[128];
+    while (fgets(line, sizeof(line), user_file) && user_count < AUTH_MAX_USERS) {
+        char *saveptr = NULL;
+        char *u = strtok_r(line, ",\n", &saveptr);
+        char *p = strtok_r(NULL, ",\n", &saveptr);
+        char *r = strtok_r(NULL, "\n", &saveptr);
+        if (!u || !p || !r) continue;
+        strncpy(users[user_count].username, u, sizeof(users[user_count].username)-1);
+        strncpy(users[user_count].pass_hash, p, sizeof(users[user_count].pass_hash)-1);
+        users[user_count].role = str_to_role(r);
+        user_count++;
+    }
+    return ESP_OK;
+}
+
+esp_err_t auth_init(void)
+{
+    if (initialized) return ESP_OK;
+    esp_vfs_spiffs_conf_t conf = {
+        .base_path = "/spiffs",
+        .partition_label = NULL,
+        .max_files = 5,
+        .format_if_mount_failed = true
+    };
+    esp_err_t ret = esp_vfs_spiffs_register(&conf);
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "SPIFFS mount failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    ret = load_file();
+    if (ret != ESP_OK) return ret;
+    initialized = true;
+    return ESP_OK;
+}
+
+esp_err_t auth_add_user(const char *username, const char *password, auth_role_t role)
+{
+    if (!initialized || !username || !password) return ESP_ERR_INVALID_STATE;
+    if (user_count >= AUTH_MAX_USERS) return ESP_ERR_NO_MEM;
+    for (size_t i = 0; i < user_count; ++i) {
+        if (strcmp(users[i].username, username) == 0) return ESP_ERR_INVALID_ARG;
+    }
+    char hash[65];
+    sha256_hex(password, hash);
+    strncpy(users[user_count].username, username, sizeof(users[user_count].username)-1);
+    strncpy(users[user_count].pass_hash, hash, sizeof(users[user_count].pass_hash)-1);
+    users[user_count].role = role;
+    user_count++;
+    return save_file();
+}
+
+esp_err_t auth_authenticate(const char *username, const char *password, auth_role_t *role_out)
+{
+    if (!initialized || !username || !password) return ESP_ERR_INVALID_STATE;
+    char hash[65];
+    sha256_hex(password, hash);
+    for (size_t i = 0; i < user_count; ++i) {
+        if (strcmp(users[i].username, username) == 0 &&
+            strcmp(users[i].pass_hash, hash) == 0) {
+            if (role_out) *role_out = users[i].role;
+            return ESP_OK;
+        }
+    }
+    return ESP_ERR_NOT_FOUND;
+}

--- a/components/auth/include/auth.h
+++ b/components/auth/include/auth.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    AUTH_ROLE_OWNER,
+    AUTH_ROLE_CARETAKER,
+    AUTH_ROLE_VET,
+    AUTH_ROLE_UNKNOWN
+} auth_role_t;
+
+esp_err_t auth_init(void);
+esp_err_t auth_add_user(const char *username, const char *password, auth_role_t role);
+esp_err_t auth_authenticate(const char *username, const char *password, auth_role_t *role_out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This directory stores project documentation.
 
 See `pin_assignments.md` for wiring instructions. See `french_eu_reptile_regs.md` for a summary of French and EU regulations on amateur reptile keeping. For details on registering your animals, read `register_animal.md`.
 Feeding logs are documented in `feeding.md`. Health records are described in `health.md`. Stock inventory is documented in `stock.md`. Purchases and sales are stored in `ledger.md`. Information about managing terrariums is in `enclosures.md`. Permit tracking and CITES obligations are covered in `permits.md`.
-Wi-Fi backup instructions are in `backup.md`.
+Wi-Fi backup instructions are in `backup.md`. Authentication and audit logging are described in `authentication.md`.
 
 ## Required Hardware
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,11 @@
+# Authentication and Roles
+
+User accounts are stored in `/spiffs/users.csv` on the device. Each line
+contains the username, a SHA‑256 hash of the password and the assigned role.
+Available roles are **owner**, **caretaker** and **vet**.
+
+Use the `auth` component APIs to add users and to verify credentials at run time.
+
+User actions are appended to `/spiffs/audit.csv` via the `audit` component.
+Each log entry records the Unix timestamp, the username and a short action
+description.

--- a/main/main.c
+++ b/main/main.c
@@ -12,6 +12,8 @@
 #include "feeding.h"
 #include "ledger.h"
 #include "permits.h"
+#include "auth.h"
+#include "audit.h"
 #include "ui.h"
 #include "settings.h"
 #include "backup.h"
@@ -21,6 +23,7 @@ static const char *TAG = "main";
 static void cleanup(void)
 {
     logger_close();
+    audit_close();
 }
 
 void app_main(void)
@@ -28,6 +31,18 @@ void app_main(void)
     ESP_LOGI(TAG, "Hello Lizard Manager!");
 
     esp_err_t err;
+
+    err = audit_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "audit_init failed: %s", esp_err_to_name(err));
+    } else {
+        audit_log("system", "boot");
+    }
+
+    err = auth_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "auth_init failed: %s", esp_err_to_name(err));
+    }
 
     err = settings_init();
     if (err != ESP_OK) {


### PR DESCRIPTION
## Summary
- implement `auth` component for role-based users
- implement `audit` component to record user actions
- initialize new modules in `app_main`
- document authentication and audit logging

## Testing
- `idf.py -C tests build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f81637088832389104e4d69125ffd